### PR TITLE
Adding UI for nu get package scanning

### DIFF
--- a/src/RepoGovernance.Tests/SummaryItemsControllerTests.cs
+++ b/src/RepoGovernance.Tests/SummaryItemsControllerTests.cs
@@ -351,6 +351,10 @@ public class SummaryItemsControllerTests : BaseAPIAccessTests
                 Assert.AreEqual("Consider disabling 'Delete branch on merge' in repo settings to streamline PR merging and auto-cleanup completed branches", item6.RepoSettingsRecommendations[1]);
                 Assert.AreEqual("Consider disabling 'Allow rebase merge' in repo settings, as rebasing can be confusing", item6.RepoSettingsRecommendations[2]);
             }
+            Assert.IsNotNull(item6.NuGetPackages);
+            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Deprecated"), 0);
+            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Outdated"), 4);
+            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Vulnerable"), 0);
         }
 
 

--- a/src/RepoGovernance.Web/Views/Home/Index.cshtml
+++ b/src/RepoGovernance.Web/Views/Home/Index.cshtml
@@ -244,10 +244,12 @@
                     {
                         <strong style="font-size:14px;">NuGet packages :</strong>
                         <br />
-                        <div>
-                            Deprecated packages: @item.NuGetPackages.Count(n=>n.Type == "Deprecated")<br>
-                            Outdated packages: @item.NuGetPackages.Count(n=>n.Type == "Outdated")<br>
-                            Vulnerable packages: @item.NuGetPackages.Count(n=>n.Type == "Vulnerable")<br>
+                        <div style="font-size:12px;">
+                            <ul>
+                                <li>Deprecated packages: @item.NuGetPackages.Count(n=>n.Type == "Deprecated")</li>
+                                <li>Outdated packages: @item.NuGetPackages.Count(n=>n.Type == "Outdated")</li>
+                                <li>Vulnerable packages: @item.NuGetPackages.Count(n=>n.Type == "Vulnerable")</li>
+                            </ul>
                         </div>
                     }
                 </div>

--- a/src/RepoGovernance.Web/Views/Home/Index.cshtml
+++ b/src/RepoGovernance.Web/Views/Home/Index.cshtml
@@ -210,7 +210,6 @@
                     @if (item.AzureDeployment != null)
                     {
                         <strong style="font-size:14px;">Azure status:</strong>
-
                         <br />
                         <div style="font-size:12px;">
                             App registrations: @item.AzureDeployment.AppRegistrations.Count<br />
@@ -239,6 +238,16 @@
                     Failed requests (last 30 days): 797<br/>
                     Server response time (avg) (last 30 days): 1.89s<br />
                     Server requests (last 30 days): *@
+                        </div>
+                    }
+                    @if (item.NuGetPackages != null && item.NuGetPackages.Count > 0)
+                    {
+                        <strong style="font-size:14px;">NuGet packages :</strong>
+                        <br />
+                        <div>
+                            Deprecated packages: @item.NuGetPackages.Count(n=>n.Type == "Deprecated")<br>
+                            Outdated packages: @item.NuGetPackages.Count(n=>n.Type == "Outdated")<br>
+                            Vulnerable packages: @item.NuGetPackages.Count(n=>n.Type == "Vulnerable")<br>
                         </div>
                     }
                 </div>


### PR DESCRIPTION
This pull request to the `RepoGovernance` project adds a new section to display the count of deprecated, outdated, and vulnerable NuGet packages in the project, and removes a bullet point before the Azure status text in the `Index.cshtml` view. It also adds assertions to test the count of these packages in the `GetSummaryItemsTest()` method in `SummaryItemsControllerTests.cs`.

* <a href="diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eR243-R254">`src/RepoGovernance.Web/Views/Home/Index.cshtml`</a>: Added a new section to display count of deprecated, outdated, and vulnerable NuGet packages in the project, and removed bullet point before Azure status text. <a href="diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eR243-R254">[1]</a> <a href="diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eL213">[2]</a>
* <a href="diffhunk://#diff-0bf21b17ba8ff36ec2fed6f940e73e848ca29003a850a7bcd048a12988694b28R354-R357">`src/RepoGovernance.Tests/SummaryItemsControllerTests.cs`</a>: Added assertions to test the count of deprecated, outdated, and vulnerable NuGet packages in `GetSummaryItemsTest()` method.