### PR TITLE
Updating nuget rules

### DIFF
--- a/src/RepoGovernance.Core/Models/SummaryItem.cs
+++ b/src/RepoGovernance.Core/Models/SummaryItem.cs
@@ -74,7 +74,8 @@ namespace RepoGovernance.Core.Models
                     DependabotRecommendations.Count +
                     BranchPoliciesRecommendations.Count +
                     GitVersionRecommendations.Count +
-                    DotNetFrameworksRecommendations.Count;
+                    DotNetFrameworksRecommendations.Count + 
+                    NuGetPackages.Count;
             }
         }
 

--- a/src/RepoGovernance.Core/SummaryItemsDA.cs
+++ b/src/RepoGovernance.Core/SummaryItemsDA.cs
@@ -1,5 +1,4 @@
 ﻿using DotNetCensus.Core.Models;
-using GitHubActionsDotNet.Models.Dependabot;
 using GitHubActionsDotNet.Serialization;
 using RepoAutomation.Core.APIAccess;
 using RepoAutomation.Core.Helpers;

--- a/src/RepoGovernance.Core/SummaryItemsDA.cs
+++ b/src/RepoGovernance.Core/SummaryItemsDA.cs
@@ -97,6 +97,11 @@ namespace RepoGovernance.Core
                 {
                     azureDeployment = existingItem.AzureDeployment;
                 }
+                //save the nuget packages - since they are updated in a separate process, and we don't want to lose them here.
+                if (existingItem != null && existingItem.NuGetPackages.Count > 0)
+                {
+                    summaryItem.NuGetPackages = existingItem.NuGetPackages;
+                }
             }
 
             try

--- a/src/RepoGovernance.Tests/SummaryItemsControllerTests.cs
+++ b/src/RepoGovernance.Tests/SummaryItemsControllerTests.cs
@@ -352,9 +352,9 @@ public class SummaryItemsControllerTests : BaseAPIAccessTests
                 Assert.AreEqual("Consider disabling 'Allow rebase merge' in repo settings, as rebasing can be confusing", item6.RepoSettingsRecommendations[2]);
             }
             Assert.IsNotNull(item6.NuGetPackages);
-            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Deprecated"), 2);
-            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Outdated"), 4);
-            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Vulnerable"), 1);
+            Assert.AreEqual(2, item6.NuGetPackages.Count(x => x.Type == "Deprecated"));
+            Assert.AreEqual(5, item6.NuGetPackages.Count(x => x.Type == "Outdated"));
+            Assert.AreEqual(1, item6.NuGetPackages.Count(x => x.Type == "Vulnerable"));
         }
 
 

--- a/src/RepoGovernance.Tests/SummaryItemsControllerTests.cs
+++ b/src/RepoGovernance.Tests/SummaryItemsControllerTests.cs
@@ -352,9 +352,9 @@ public class SummaryItemsControllerTests : BaseAPIAccessTests
                 Assert.AreEqual("Consider disabling 'Allow rebase merge' in repo settings, as rebasing can be confusing", item6.RepoSettingsRecommendations[2]);
             }
             Assert.IsNotNull(item6.NuGetPackages);
-            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Deprecated"), 0);
+            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Deprecated"), 2);
             Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Outdated"), 4);
-            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Vulnerable"), 0);
+            Assert.AreEqual(item6.NuGetPackages.Count(x => x.Type == "Vulnerable"), 1);
         }
 
 

--- a/src/RepoGovernance.Web/Views/Home/Index.cshtml
+++ b/src/RepoGovernance.Web/Views/Home/Index.cshtml
@@ -84,7 +84,7 @@
                            item.BranchPolicies != null && item.BranchPoliciesRecommendations.Count == 0 &&
                            item.Actions.Count > 0 && item.ActionRecommendations.Count == 0 &&
                            item.Dependabot.Count > 0 && item.DependabotRecommendations.Count == 0 &&
-                           item.GitVersion.Count > 0 && item.GitVersionRecommendations.Count == 0 && 
+                           item.GitVersion.Count > 0 && item.GitVersionRecommendations.Count == 0 &&
                            item.NuGetPackages != null && item.NuGetPackages.Count == 0)
                             {
                                 <i class="bi bi-heart-fill greenHeart" data-toggle="tooltip" data-placement="bottom" title="OK"></i> <span>0</span>
@@ -112,7 +112,7 @@
                                 {
                                     recommendation += " - " + itemRec + Environment.NewLine + Environment.NewLine;
                                 }
-                                if (item!= null && item.NuGetPackages != null && item.NuGetPackages.Count > 0)
+                                if (item != null && item.NuGetPackages != null && item.NuGetPackages.Count > 0)
                                 {
                                     recommendation += " - " + item.NuGetPackages.Count.ToString() + " NuGet packages require upgrades" + Environment.NewLine + Environment.NewLine;
                                 }

--- a/src/RepoGovernance.Web/Views/Home/Index.cshtml
+++ b/src/RepoGovernance.Web/Views/Home/Index.cshtml
@@ -111,6 +111,10 @@
                                 {
                                     recommendation += " - " + itemRec + Environment.NewLine + Environment.NewLine;
                                 }
+                                if (item!= null && item.NuGetPackages != null && item.NuGetPackages.Count > 0)
+                                {
+                                    recommendation += " - " + item.NuGetPackages.Count.ToString() + " NuGet packages require upgrades" + Environment.NewLine + Environment.NewLine;
+                                }
                                 <i class="bi bi-heart-pulse redHeart" data-toggle="tooltip" data-placement="bottom" title="@recommendation"></i> <span style="font-size: 14px;">@item.TotalRecommendationCount</span>
                             }
                         }
@@ -242,7 +246,7 @@
                     }
                     @if (item.NuGetPackages != null && item.NuGetPackages.Count > 0)
                     {
-                        <strong style="font-size:14px;">NuGet packages :</strong>
+                        <strong style="font-size:14px;">NuGet updates required:</strong>
                         <br />
                         <div style="font-size:12px;">
                             <ul>

--- a/src/RepoGovernance.Web/Views/Home/Index.cshtml
+++ b/src/RepoGovernance.Web/Views/Home/Index.cshtml
@@ -80,11 +80,12 @@
                     <div>
                         @if (item.TotalRecommendationCount >= 0)
                         {
-                            @if (item.RepoSettingsRecommendations.Count == 0 &&
+                            @if (item != null && item.RepoSettingsRecommendations.Count == 0 &&
                            item.BranchPolicies != null && item.BranchPoliciesRecommendations.Count == 0 &&
                            item.Actions.Count > 0 && item.ActionRecommendations.Count == 0 &&
                            item.Dependabot.Count > 0 && item.DependabotRecommendations.Count == 0 &&
-                           item.GitVersion.Count > 0 && item.GitVersionRecommendations.Count == 0)
+                           item.GitVersion.Count > 0 && item.GitVersionRecommendations.Count == 0 && 
+                           item.NuGetPackages != null && item.NuGetPackages.Count == 0)
                             {
                                 <i class="bi bi-heart-fill greenHeart" data-toggle="tooltip" data-placement="bottom" title="OK"></i> <span>0</span>
                             }


### PR DESCRIPTION
This pull request to the `RepoGovernance` project includes changes to save NuGet packages to summary items, update import statements, and display the number of required NuGet package updates on the Home/Index view. The most important changes are:

* <a href="diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eL245-R250">`src/RepoGovernance.Web/Views/Home/Index.cshtml`</a>: The Home/Index view now displays the number of required NuGet package updates and updates the corresponding icon and count if there are no recommendations. <a href="diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eL245-R250">[1]</a> <a href="diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eR115-R118">[2]</a> <a href="diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eL83-R88">[3]</a>
* <a href="diffhunk://#diff-391c44763ee0e9edf4427815b3cf24ac46f02014f1ebf3618f5a18bafc5bc2acL77-R78">`src/RepoGovernance.Core/Models/SummaryItem.cs`</a>: Added count of NuGet packages to recommendation count in SummaryItem model.
* <a href="diffhunk://#diff-778983c3f2b31fe32177d3181f5b3de225313050c8581b6d9fa86690679976b6R100-R104">`src/RepoGovernance.Core/SummaryItemsDA.cs`</a>: Saving NuGet packages to summary items and updating import statements in `SummaryItemsDA.cs`. <a href="diffhunk://#diff-778983c3f2b31fe32177d3181f5b3de225313050c8581b6d9fa86690679976b6R100-R104">[1]</a> <a href="diffhunk://#diff-778983c3f2b31fe32177d3181f5b3de225313050c8581b6d9fa86690679976b6L2">[2]</a>