### PR TITLE
Created new workflow file for nightly process

### DIFF
--- a/.github/workflows/nightlyprocess.yml
+++ b/.github/workflows/nightlyprocess.yml
@@ -1,0 +1,232 @@
+name: Run job
+
+on:
+  schedule:
+  # weekly at 7am on Mondays  
+  - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  processRepos:
+    name: Process repos
+    env:
+      user: samsmithnz
+    strategy:
+      matrix:
+        repo: ['samsmithnz/AzurePipelinesToGitHubActionsConverter','samsmithnz/AzurePipelinesToGitHubActionsConverterWeb','samsmithnz/CustomQueue','samsmithnz/Dependabot-Configuration-Builder','samsmithnz/DotNetCensus','samsmithnz/DSPTree','samsmithnz/FactorySim','samsmithnz/GitHubActionsDotNet','samsmithnz/MermaidDotNet','samsmithnz/RepoAutomation','samsmithnz/RepoAutomationUnitTests','samsmithnz/RepoGovernance','samsmithnz/SamsFeatureFlags','samsmithnz/SatisfactoryTree','samsmithnz/SamsDotNetSonarCloudAction','samsmithnz/TurnBasedEngine','SamSmithNZ-dotcom/SamSmithNZ.com','SamSmithNZ-dotcom/MandMCounter','DeveloperMetrics/DevOpsMetrics','DeveloperMetrics/deployment-frequency','DeveloperMetrics/lead-time-for-changes'] 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: ${{ matrix.repo }}
+        token: ${{ secrets.PAT_TOKEN }}
+        path: newRepo
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    - name: Scan for NuGet packages needing action
+      continue-on-error: true
+      shell: pwsh
+      run: |
+        if (Test-Path newRepo/src/*.sln -PathType Leaf)
+        {
+          cd newRepo/src 
+          dotnet restore
+          #ls
+          $resultDeprecated = dotnet list package --deprecated --format json
+          if ($resultDeprecated.length -gt 40000)
+          {
+            write-host "Deprecated result is too large to be assigned to an environment variable."
+          }
+          else 
+          {
+            $deprecatedCount = 0
+            foreach ($project in ($resultDeprecated | ConvertFrom-Json).projects)
+            {
+              # write-host "Scanning project"
+              # write-host $project
+              # write-host $project.frameworks
+              # write-host $project.frameworks.Count
+              $deprecatedCount += $project.frameworks.Count
+            }
+            $resultDeprecated
+            #write-host "Deprecated projects found: $($resultDeprecated.projects.Count)"
+            write-host "Deprecated results found: $deprecatedCount"
+          }
+          $resultOutDated = dotnet list package --outdated --format json
+          if ($resultOutDated.length -gt 40000)
+          {
+            write-host "Outdated result is too large to be assigned to an environment variable."
+          }
+          else 
+          {
+            $outdatedCount = 0
+            foreach ($project in ($resultOutdated | ConvertFrom-Json).projects)
+            {
+              $outdatedCount += $project.frameworks.Count
+            }
+            write-host "Outdated results found: $outdatedCount"
+          }
+          $resultVulnerable = dotnet list package --vulnerable --format json
+          if ($resultVulnerable.length -gt 40000)
+          {
+            write-host "Vulnerable result is too large to be assigned to an environment variable."
+          }
+          else 
+          {
+            $vulnerableCount = 0
+            foreach ($project in ($resultVulnerable | ConvertFrom-Json).projects)          
+            {
+              $vulnerableCount += $project.frameworks.Count
+            }
+            write-host "Vulnerable results found: $vulnerableCount"
+          }
+          $user = "${{ env.user }}"
+          $owner = "${{ matrix.repo }}".split('/')[0]
+          $repo = "${{ matrix.repo }}".split('/')[1]
+          #Deprecated packages
+          $NuGetDeprecatedPayload = @{
+            User = $user
+            Owner = $owner
+            Repo = $repo
+            JsonPayload = $resultDeprecated
+            PayloadType = "Deprecated"
+          } | ConvertTo-Json -Depth 5
+          Invoke-WebRequest -Uri https://repogovernance-prod-eu-service.azurewebsites.net/api/SummaryItems/UpdateSummaryItemNuGetPackageStats -ContentType "application/json" -Method POST -Body $NuGetDeprecatedPayload
+          #Outdated packages
+          $NuGetOutdatedPayload = @{
+            User = $user
+            Owner = $owner
+            Repo = $repo
+            JsonPayload = $resultOutDated
+            PayloadType = "Outdated"
+          } | ConvertTo-Json -Depth 5
+          Invoke-WebRequest -Uri https://repogovernance-prod-eu-service.azurewebsites.net/api/SummaryItems/UpdateSummaryItemNuGetPackageStats -ContentType "application/json" -Method POST -Body $NuGetOutdatedPayload
+          #Vulnerable packages        
+          $NuGetVulnerablePayload = @{
+            User = $user
+            Owner = $owner
+            Repo = $repo
+            JsonPayload = $resultVulnerable
+            PayloadType = "Vulnerable"
+          } | ConvertTo-Json -Depth 5
+          Invoke-WebRequest -Uri https://repogovernance-prod-eu-service.azurewebsites.net/api/SummaryItems/UpdateSummaryItemNuGetPackageStats -ContentType "application/json" -Method POST -Body $NuGetVulnerablePayload
+        }
+        else
+        {
+          write-host "No .NET solution found"
+          #write-error "No .NET solution found"
+        }
+
+
+  processWindowsRepos:
+    name: Process repos
+    env:
+      user: samsmithnz
+    strategy:
+      matrix:
+        repo: ['samsmithnz/PuzzleSolver','samsmithnz/ResearchTree','samsmithnz/Sams2048']
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: ${{ matrix.repo }}
+        token: ${{ secrets.PAT_TOKEN }}
+        path: newRepo
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    - name: Scan for NuGet packages needing action
+      shell: pwsh
+      run: |
+        if (Test-Path newRepo/src/*.sln -PathType Leaf)
+        {
+          cd newRepo/src 
+          dotnet restore
+          #ls
+          $resultDeprecated = dotnet list package --deprecated --format json
+          if ($resultDeprecated.length -gt 40000)
+          {
+            write-host "Deprecated result is too large to be assigned to an environment variable."
+          }
+          else 
+          {
+            $deprecatedCount = 0
+            foreach ($project in ($resultDeprecated | ConvertFrom-Json).projects)
+            {
+              # write-host "Scanning project"
+              # write-host $project
+              # write-host $project.frameworks
+              # write-host $project.frameworks.Count
+              $deprecatedCount += $project.frameworks.Count
+            }
+            $resultDeprecated
+            #write-host "Deprecated projects found: $($resultDeprecated.projects.Count)"
+            write-host "Deprecated results found: $deprecatedCount"
+          }
+          $resultOutDated = dotnet list package --outdated --format json
+          if ($resultOutDated.length -gt 40000)
+          {
+            write-host "Outdated result is too large to be assigned to an environment variable."
+          }
+          else 
+          {
+            $outdatedCount = 0
+            foreach ($project in ($resultOutdated | ConvertFrom-Json).projects)
+            {
+              $outdatedCount += $project.frameworks.Count
+            }
+            write-host "Outdated results found: $outdatedCount"
+          }
+          $resultVulnerable = dotnet list package --vulnerable --format json
+          if ($resultVulnerable.length -gt 40000)
+          {
+            write-host "Vulnerable result is too large to be assigned to an environment variable."
+          }
+          else 
+          {
+            $vulnerableCount = 0
+            foreach ($project in ($resultVulnerable | ConvertFrom-Json).projects)          
+            {
+              $vulnerableCount += $project.frameworks.Count
+            }
+            write-host "Vulnerable results found: $vulnerableCount"
+          }
+          $user = "${{ env.user }}"
+          $owner = "${{ matrix.repo }}".split('/')[0]
+          $repo = "${{ matrix.repo }}".split('/')[1]
+          #Deprecated packages
+          $NuGetDeprecatedPayload = @{
+            User = $user
+            Owner = $owner
+            Repo = $repo
+            JsonPayload = $resultDeprecated
+            PayloadType = "Deprecated"
+          } | ConvertTo-Json -Depth 5
+          Invoke-WebRequest -Uri https://repogovernance-prod-eu-service.azurewebsites.net/api/SummaryItems/UpdateSummaryItemNuGetPackageStats -ContentType "application/json" -Method POST -Body $NuGetDeprecatedPayload
+          #Outdated packages
+          $NuGetOutdatedPayload = @{
+            User = $user
+            Owner = $owner
+            Repo = $repo
+            JsonPayload = $resultOutDated
+            PayloadType = "Outdated"
+          } | ConvertTo-Json -Depth 5
+          Invoke-WebRequest -Uri https://repogovernance-prod-eu-service.azurewebsites.net/api/SummaryItems/UpdateSummaryItemNuGetPackageStats -ContentType "application/json" -Method POST -Body $NuGetOutdatedPayload
+          #Vulnerable packages        
+          $NuGetVulnerablePayload = @{
+            User = $user
+            Owner = $owner
+            Repo = $repo
+            JsonPayload = $resultVulnerable
+            PayloadType = "Vulnerable"
+          } | ConvertTo-Json -Depth 5
+          Invoke-WebRequest -Uri https://repogovernance-prod-eu-service.azurewebsites.net/api/SummaryItems/UpdateSummaryItemNuGetPackageStats -ContentType "application/json" -Method POST -Body $NuGetVulnerablePayload
+        }
+        else
+        {
+          write-host "No .NET solution found"
+          #write-error "No .NET solution found"
+        }

--- a/src/RepoGovernance.sln
+++ b/src/RepoGovernance.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\.github\dependabot.yml = ..\.github\dependabot.yml
 		..\GitVersion.yml = ..\GitVersion.yml
+		..\.github\workflows\nightlyprocess.yml = ..\.github\workflows\nightlyprocess.yml
 		..\README.md = ..\README.md
 		..\.github\workflows\workflow.yml = ..\.github\workflows\workflow.yml
 	EndProjectSection


### PR DESCRIPTION
This pull request adds a new workflow file to update NuGet package stats for several repositories owned by `samsmithnz`. The workflow runs weekly on Mondays at 7 am and can also be triggered manually. The most important changes include adding the new workflow file to the `Solution Items` section in the `src/RepoGovernance.sln` file and defining two jobs in the `nightlyprocess.yml` file.

Main changes:

* <a href="diffhunk://#diff-75e6f2a777c113736a4387fad4d0474f3a9f0e13bed42c52038339dac9bad4d8R16">`src/RepoGovernance.sln`</a>: A new workflow file has been added to update NuGet package stats for several repositories owned by `samsmithnz`, and it runs weekly on Mondays at 7 am. The change also adds the new workflow file to the `Solution Items` section.
* <a href="diffhunk://#diff-a4368cd11d3737824faccc9578caf76de4a76b9ac0e47b29f0896f18c716bfd6R1-R232">`.github/workflows/nightlyprocess.yml`</a>: Added a new workflow file `nightlyprocess.yml` that defines two jobs to process several repositories owned by `samsmithnz` and update NuGet package stats. The workflow runs weekly on Mondays at 7 am and can also be triggered manually.