### PR TITLE
Rearranged UI

### DIFF
--- a/src/RepoGovernance.Web/Controllers/HomeController.cs
+++ b/src/RepoGovernance.Web/Controllers/HomeController.cs
@@ -18,56 +18,56 @@ public class HomeController : Controller
 
     public async Task<IActionResult> Index(bool isContributor = false)
     {
-        //string currentUser = "samsmithnz";
-        //List<SummaryItem> summaryItems = await _ServiceApiClient.GetSummaryItems(currentUser);
-        //List<RepoLanguage> repoLanguages = new();
-        //Dictionary<string, int> repoLanguagesDictonary = new();
-        //int total = 0;
-        //foreach (SummaryItem summaryItem in summaryItems)
-        //{
-        //    foreach (RepoLanguage repoLanguage in summaryItem.RepoLanguages)
-        //    {
-        //        total += repoLanguage.Total;
-        //        if (repoLanguage.Name != null)
-        //        {
-        //            if (repoLanguagesDictonary.ContainsKey(repoLanguage.Name))
-        //            {
-        //                repoLanguagesDictonary[repoLanguage.Name] += repoLanguage.Total;
-        //            }
-        //            else
-        //            {
-        //                repoLanguagesDictonary.Add(repoLanguage.Name, repoLanguage.Total);
-        //            }
-        //            if (repoLanguages.Find(x => x.Name == repoLanguage.Name) == null)
-        //            {
-        //                repoLanguages.Add(new RepoLanguage
-        //                {
-        //                    Name = repoLanguage.Name,
-        //                    Total = repoLanguage.Total,
-        //                    Color = repoLanguage.Color,
-        //                    Percent = repoLanguage.Percent
-        //                });
-        //            }
-        //        }
-        //    }
-        //}
-        ////Update the percent
-        //foreach (KeyValuePair<string, int> sortedLanguage in repoLanguagesDictonary.OrderByDescending(x => x.Value))
-        //{
-        //    RepoLanguage? repoLanguage = repoLanguages.Find(x => x.Name == sortedLanguage.Key);
-        //    if (repoLanguage != null)
-        //    {
-        //        repoLanguage.Total = sortedLanguage.Value;
-        //        repoLanguage.Percent = Math.Round((decimal)repoLanguage.Total / (decimal)total * 100M, 1);
-        //    }
-        //}
+        string currentUser = "samsmithnz";
+        List<SummaryItem> summaryItems = await _ServiceApiClient.GetSummaryItems(currentUser);
+        List<RepoLanguage> repoLanguages = new();
+        Dictionary<string, int> repoLanguagesDictonary = new();
+        int total = 0;
+        foreach (SummaryItem summaryItem in summaryItems)
+        {
+            foreach (RepoLanguage repoLanguage in summaryItem.RepoLanguages)
+            {
+                total += repoLanguage.Total;
+                if (repoLanguage.Name != null)
+                {
+                    if (repoLanguagesDictonary.ContainsKey(repoLanguage.Name))
+                    {
+                        repoLanguagesDictonary[repoLanguage.Name] += repoLanguage.Total;
+                    }
+                    else
+                    {
+                        repoLanguagesDictonary.Add(repoLanguage.Name, repoLanguage.Total);
+                    }
+                    if (repoLanguages.Find(x => x.Name == repoLanguage.Name) == null)
+                    {
+                        repoLanguages.Add(new RepoLanguage
+                        {
+                            Name = repoLanguage.Name,
+                            Total = repoLanguage.Total,
+                            Color = repoLanguage.Color,
+                            Percent = repoLanguage.Percent
+                        });
+                    }
+                }
+            }
+        }
+        //Update the percent
+        foreach (KeyValuePair<string, int> sortedLanguage in repoLanguagesDictonary.OrderByDescending(x => x.Value))
+        {
+            RepoLanguage? repoLanguage = repoLanguages.Find(x => x.Name == sortedLanguage.Key);
+            if (repoLanguage != null)
+            {
+                repoLanguage.Total = sortedLanguage.Value;
+                repoLanguage.Percent = Math.Round((decimal)repoLanguage.Total / (decimal)total * 100M, 1);
+            }
+        }
 
-        SummaryItemsIndex summaryItemsIndex = new();
-        //{
-        //    SummaryItems = summaryItems,
-        //    SummaryRepoLanguages = repoLanguages.OrderByDescending(x => x.Total).ToList(),
-        //    IsContributor = isContributor
-        //};
+        SummaryItemsIndex summaryItemsIndex = new()
+        {
+            SummaryItems = summaryItems,
+            SummaryRepoLanguages = repoLanguages.OrderByDescending(x => x.Total).ToList(),
+            IsContributor = isContributor
+        };
         return View(summaryItemsIndex);
     }
 

--- a/src/RepoGovernance.Web/Controllers/HomeController.cs
+++ b/src/RepoGovernance.Web/Controllers/HomeController.cs
@@ -18,56 +18,56 @@ public class HomeController : Controller
 
     public async Task<IActionResult> Index(bool isContributor = false)
     {
-        string currentUser = "samsmithnz";
-        List<SummaryItem> summaryItems = await _ServiceApiClient.GetSummaryItems(currentUser);
-        List<RepoLanguage> repoLanguages = new();
-        Dictionary<string, int> repoLanguagesDictonary = new();
-        int total = 0;
-        foreach (SummaryItem summaryItem in summaryItems)
-        {
-            foreach (RepoLanguage repoLanguage in summaryItem.RepoLanguages)
-            {
-                total += repoLanguage.Total;
-                if (repoLanguage.Name != null)
-                {
-                    if (repoLanguagesDictonary.ContainsKey(repoLanguage.Name))
-                    {
-                        repoLanguagesDictonary[repoLanguage.Name] += repoLanguage.Total;
-                    }
-                    else
-                    {
-                        repoLanguagesDictonary.Add(repoLanguage.Name, repoLanguage.Total);
-                    }
-                    if (repoLanguages.Find(x => x.Name == repoLanguage.Name) == null)
-                    {
-                        repoLanguages.Add(new RepoLanguage
-                        {
-                            Name = repoLanguage.Name,
-                            Total = repoLanguage.Total,
-                            Color = repoLanguage.Color,
-                            Percent = repoLanguage.Percent
-                        });
-                    }
-                }
-            }
-        }
-        //Update the percent
-        foreach (KeyValuePair<string, int> sortedLanguage in repoLanguagesDictonary.OrderByDescending(x => x.Value))
-        {
-            RepoLanguage? repoLanguage = repoLanguages.Find(x => x.Name == sortedLanguage.Key);
-            if (repoLanguage != null)
-            {
-                repoLanguage.Total = sortedLanguage.Value;
-                repoLanguage.Percent = Math.Round((decimal)repoLanguage.Total / (decimal)total * 100M, 1);
-            }
-        }
+        //string currentUser = "samsmithnz";
+        //List<SummaryItem> summaryItems = await _ServiceApiClient.GetSummaryItems(currentUser);
+        //List<RepoLanguage> repoLanguages = new();
+        //Dictionary<string, int> repoLanguagesDictonary = new();
+        //int total = 0;
+        //foreach (SummaryItem summaryItem in summaryItems)
+        //{
+        //    foreach (RepoLanguage repoLanguage in summaryItem.RepoLanguages)
+        //    {
+        //        total += repoLanguage.Total;
+        //        if (repoLanguage.Name != null)
+        //        {
+        //            if (repoLanguagesDictonary.ContainsKey(repoLanguage.Name))
+        //            {
+        //                repoLanguagesDictonary[repoLanguage.Name] += repoLanguage.Total;
+        //            }
+        //            else
+        //            {
+        //                repoLanguagesDictonary.Add(repoLanguage.Name, repoLanguage.Total);
+        //            }
+        //            if (repoLanguages.Find(x => x.Name == repoLanguage.Name) == null)
+        //            {
+        //                repoLanguages.Add(new RepoLanguage
+        //                {
+        //                    Name = repoLanguage.Name,
+        //                    Total = repoLanguage.Total,
+        //                    Color = repoLanguage.Color,
+        //                    Percent = repoLanguage.Percent
+        //                });
+        //            }
+        //        }
+        //    }
+        //}
+        ////Update the percent
+        //foreach (KeyValuePair<string, int> sortedLanguage in repoLanguagesDictonary.OrderByDescending(x => x.Value))
+        //{
+        //    RepoLanguage? repoLanguage = repoLanguages.Find(x => x.Name == sortedLanguage.Key);
+        //    if (repoLanguage != null)
+        //    {
+        //        repoLanguage.Total = sortedLanguage.Value;
+        //        repoLanguage.Percent = Math.Round((decimal)repoLanguage.Total / (decimal)total * 100M, 1);
+        //    }
+        //}
 
-        SummaryItemsIndex summaryItemsIndex = new()
-        {
-            SummaryItems = summaryItems,
-            SummaryRepoLanguages = repoLanguages.OrderByDescending(x => x.Total).ToList(),
-            IsContributor = isContributor
-        };
+        SummaryItemsIndex summaryItemsIndex = new();
+        //{
+        //    SummaryItems = summaryItems,
+        //    SummaryRepoLanguages = repoLanguages.OrderByDescending(x => x.Total).ToList(),
+        //    IsContributor = isContributor
+        //};
         return View(summaryItemsIndex);
     }
 

--- a/src/RepoGovernance.Web/Views/Home/Index.cshtml
+++ b/src/RepoGovernance.Web/Views/Home/Index.cshtml
@@ -8,7 +8,7 @@
     TimeSpan ts = new();
     string lastUpdated = "[unknown]";
     string user = "[unknown]";
-    if (Model.SummaryItems.Count > 0)
+    if (Model.SummaryItems != null && Model.SummaryItems.Count > 0)
     {
         DateTime minDate = DateTime.Now;
         DateTime maxDate = DateTime.Now;
@@ -27,6 +27,12 @@
         lastUpdated = maxDate.ToString("dd-MMM-yyyy h:mm:sstt");
         user = Model.SummaryItems[0].User;
     }
+    else
+    {
+        Model.SummaryItems = new();
+        Model.SummaryRepoLanguages = new();
+        Model.IsContributor = true;
+    }
 }
 
 <div>
@@ -42,7 +48,6 @@
                 <span class="badge bg-primary">Total PRs: @Model.SummaryItems.Sum(x => x.PullRequests.Count)</span> &nbsp;
                 <span class="badge bg-primary">Total issues: @Model.SummaryItems.Sum(x => x.TotalRecommendationCount)</span>
             </div>
-            <br />
         </div>
         <div class="col-md-6">
             <h4>&nbsp;</h4>
@@ -58,7 +63,16 @@
                     }
                 }
             </div>
-            <br />
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-6">
+            @if (Model.IsContributor)
+            {
+                <a href="@Url.Action("UpdateAll", "Home", new { isContributor = Model.IsContributor })" class="lastUpdatedText">Update all. Warning- takes a ~minute</a>
+                <br />
+                <a href="@Url.Action("ApprovePRsForAllRepos", "Home", new { isContributor = Model.IsContributor })" class="lastUpdatedText">Approve all open PRs. Warning- takes a ~minute</a>
+            }
         </div>
     </div>
     <div>
@@ -251,9 +265,9 @@
                         <br />
                         <div style="font-size:12px;">
                             <ul>
-                                <li>Deprecated packages: @item.NuGetPackages.Count(n=>n.Type == "Deprecated")</li>
-                                <li>Outdated packages: @item.NuGetPackages.Count(n=>n.Type == "Outdated")</li>
-                                <li>Vulnerable packages: @item.NuGetPackages.Count(n=>n.Type == "Vulnerable")</li>
+                                <li>Deprecated packages: @item.NuGetPackages.Count(n => n.Type == "Deprecated")</li>
+                                <li>Outdated packages: @item.NuGetPackages.Count(n => n.Type == "Outdated")</li>
+                                <li>Vulnerable packages: @item.NuGetPackages.Count(n => n.Type == "Vulnerable")</li>
                             </ul>
                         </div>
                     }
@@ -310,15 +324,6 @@
                     }
                 </div>
             </div>
-        }
-    </div>
-    <div>
-        @if (Model.IsContributor)
-        {
-            <a href="@Url.Action("UpdateAll", "Home", new { isContributor = Model.IsContributor })" class="lastUpdatedText">Update all. Warning- takes a ~minute</a>
-
-            <br />
-            <a href="@Url.Action("ApprovePRsForAllRepos", "Home", new { isContributor = Model.IsContributor })" class="lastUpdatedText">Approve all open PRs. Warning- takes a ~minute</a>
         }
     </div>
 </div>


### PR DESCRIPTION
This pull request primarily involves changes in the `HomeController.cs` and `Index.cshtml` files within the `src/RepoGovernance.Web` directory. The changes aim to refactor and optimize the codebase, with a focus on handling null values and improving the layout of the page.

Codebase Refactoring:

* [`src/RepoGovernance.Web/Controllers/HomeController.cs`](diffhunk://#diff-ab97d10ef5f6fb557fac176e85817500755a622864afb948414d5541cb1b717eL21-R70): A large block of code handling the retrieval and processing of `SummaryItems` and `RepoLanguages` has been commented out, and the `SummaryItemsIndex` object is now initialized without any parameters. This suggests a shift in how this data is handled, possibly moving towards a more modular approach or a different data retrieval method.

Handling Null Values:

* [`src/RepoGovernance.Web/Views/Home/Index.cshtml`](diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eL11-R11): Added null check for `Model.SummaryItems` before accessing its `Count` property to prevent potential NullReferenceException.
* [`src/RepoGovernance.Web/Views/Home/Index.cshtml`](diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eR30-R35): In the case where `Model.SummaryItems` is null, it is now initialized to a new list. The same is done for `Model.SummaryRepoLanguages`, and `Model.IsContributor` is set to true.

Layout Improvements:

* [`src/RepoGovernance.Web/Views/Home/Index.cshtml`](diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eL45): Removed a line break for a cleaner layout.
* [`src/RepoGovernance.Web/Views/Home/Index.cshtml`](diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eR66-R75): The links for "Update all" and "Approve all open PRs" have been moved to a new location in the layout. This change could be aimed at improving the user experience by making these options more visible or logically placed. [[1]](diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eR66-R75) [[2]](diffhunk://#diff-1347693b267d7aa2924ae5a8f657f900adb1a5a00a2b3126f95dea146366593eL315-L323)