### PR TITLE
Updated packages

### DIFF
--- a/src/RepoGovernance.Core/RepoGovernance.Core.csproj
+++ b/src/RepoGovernance.Core/RepoGovernance.Core.csproj
@@ -10,10 +10,10 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="DotNetCensus.Core" Version="1.8.6" />
-    <PackageReference Include="GitHubActionsDotNet" Version="1.3.19" />
+    <PackageReference Include="GitHubActionsDotNet" Version="1.3.21" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Graph" Version="5.52.0" />
-    <PackageReference Include="RepoAutomation.Core" Version="1.6.3" />
+    <PackageReference Include="Microsoft.Graph" Version="5.55.0" />
+    <PackageReference Include="RepoAutomation.Core" Version="1.6.4" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />	  
   </ItemGroup>
 

--- a/src/RepoGovernance.Function/RepoGovernance.Function.csproj
+++ b/src/RepoGovernance.Function/RepoGovernance.Function.csproj
@@ -5,7 +5,7 @@
     <UserSecretsId>56a80713-9f41-47ac-bcbe-6d61d992bf79</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.17.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />

--- a/src/RepoGovernance.Service/RepoGovernance.Service.csproj
+++ b/src/RepoGovernance.Service/RepoGovernance.Service.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RepoGovernance.Tests/RepoGovernance.Tests.csproj
+++ b/src/RepoGovernance.Tests/RepoGovernance.Tests.csproj
@@ -33,9 +33,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This pull request primarily focuses on updating the versions of various packages across multiple projects in the solution. The updates are made in the `.csproj` files of the respective projects. The changes are grouped by the project they belong to.

Package version updates:

* [`src/RepoGovernance.Core/RepoGovernance.Core.csproj`](diffhunk://#diff-40df9e7d7ab1f39710cbd4a6bb1e668981147ca5cc04266f892af55197368343L13-R16): Updated the versions of `GitHubActionsDotNet` from `1.3.19` to `1.3.21`, `Microsoft.Graph` from `5.52.0` to `5.55.0`, and `RepoAutomation.Core` from `1.6.3` to `1.6.4`.
* [`src/RepoGovernance.Function/RepoGovernance.Function.csproj`](diffhunk://#diff-dd9ca83e38a2cd3fac3d5998d6e335461ad39216dad86f50eda6ac34ca88c375L8-R8): Updated the version of `Azure.Storage.Queues` from `12.17.1` to `12.18.0`.
* [`src/RepoGovernance.Service/RepoGovernance.Service.csproj`](diffhunk://#diff-4710bc5bb7365ad4d2ef305b03e09b7e6882aa7396d0d2d6a360a5aa888b8bdbL13-R13): Updated the version of `Swashbuckle.AspNetCore` from `6.5.0` to `6.6.2`.
* [`src/RepoGovernance.Tests/RepoGovernance.Tests.csproj`](diffhunk://#diff-9c4d088c5460e31ff7d20cb95fb25ff29defed1248cfb78c88c6660e517ecb93L36-R38): Updated the versions of `Microsoft.NET.Test.Sdk` from `17.9.0` to `17.10.0`, `MSTest.TestAdapter` from `3.3.1` to `3.4.3`, and `MSTest.TestFramework` from `3.3.1` to `3.4.3`.